### PR TITLE
fixed logistic regression

### DIFF
--- a/R/logistic_regression.R
+++ b/R/logistic_regression.R
@@ -7,6 +7,13 @@
 #' @return List containing coefficients, fitted values, and model summary.
 #' @export
 logistic_regression <- function(X, y) {
+  if (!is.numeric(y) || length(unique(y)) != 2) {
+    stop("Response variable y must be binary for logistic regression.")
+  }
+
+  # Convert y to a factor with levels 0 and 1
+  y <- factor(y)
+
   fit <- glm(y ~ X, family = binomial(link = "logit"))
   coefficients <- coef(fit)
   fitted_values <- fitted(fit)

--- a/tests/test_logistic_regression.R
+++ b/tests/test_logistic_regression.R
@@ -11,13 +11,10 @@ X_binary <- matrix(rnorm(100), ncol = 2)
 y_binary <- sample(c(0, 1), 50, replace = TRUE)
 
 # Test logistic_regression function for continuous y
-test_that("logistic_regression function works for continuous y", {
-  result_continuous <- logistic_regression(X_continuous, y_continuous)
-  expect_true("coefficients" %in% names(result_continuous))
-  expect_true("fitted_values" %in% names(result_continuous))
-  expect_true("summary" %in% names(result_continuous))
+test_that("logistic_regression function handles continuous y", {
+  expect_error(logistic_regression(X_continuous, y_continuous),
+               "Response variable y must be binary for logistic regression.")
 })
-
 # Test logistic_regression function for binary y
 test_that("logistic_regression function works for binary y", {
   result_binary <- logistic_regression(X_binary, y_binary)
@@ -25,3 +22,12 @@ test_that("logistic_regression function works for binary y", {
   expect_true("fitted_values" %in% names(result_binary))
   expect_true("summary" %in% names(result_binary))
 })
+
+# Additional tests for edge cases
+test_that("logistic_regression function handles invalid input", {
+  expect_error(logistic_regression(X_continuous, rep(0, 50)),
+               "Response variable y must be binary for logistic regression.")
+  expect_error(logistic_regression(X_binary, rep(0, 50)),
+               "Response variable y must be binary for logistic regression.")
+})
+


### PR DESCRIPTION
the logistic regression should not work for cases when y is not binary. Hence adding a stop clause when target y is set to be non binary. Updated the test cases to catch the corresponding errors. 